### PR TITLE
projection_class error corrected

### DIFF
--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -65,7 +65,7 @@ module EntityStore
       end
 
       if instance.projection_class.nil?
-        raise Error, "Reader is not declared"
+        raise Error, "Projection is not declared"
       end
 
       if instance.reader_class.nil?


### PR DESCRIPTION
When an `EntityStore` does not declare a `projection_class`, the error complained of a missing `Reader`.