### PR TITLE
Reader macro accepts batch size argument

### DIFF
--- a/entity_store.gemspec
+++ b/entity_store.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name = 'evt-entity_store'
-  s.version = '0.5.1.1'
+  s.version = '0.5.1.2'
   s.summary = 'Store of entities that are projected from streams'
   s.description = ' '
 

--- a/lib/entity_store/controls/entity_store.rb
+++ b/lib/entity_store/controls/entity_store.rb
@@ -1,18 +1,18 @@
 module EntityStore
   module Controls
     module EntityStore
-      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
-        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && reader_batch_size.nil? && reader_batch_size_keyword.nil?
+      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil)
+        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && reader_batch_size.nil?
           store_class = Example
         else
-          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, reader_batch_size: reader_batch_size, reader_batch_size_keyword: reader_batch_size_keyword)
+          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, reader_batch_size: reader_batch_size)
         end
 
         instance = store_class.build
         instance
       end
 
-      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
+      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil)
         if category == :none
           category = nil
         else
@@ -49,12 +49,7 @@ module EntityStore
           category category
           entity entity_class
           projection projection_class
-
-          if reader_batch_size_keyword.nil?
-            reader reader_class, reader_batch_size
-          else
-            reader reader_class, batch_size: reader_batch_size_keyword
-          end
+          reader reader_class, batch_size: reader_batch_size
 
           unless snapshot_class.nil?
             if snapshot_interval_keyword.nil?

--- a/lib/entity_store/controls/entity_store.rb
+++ b/lib/entity_store/controls/entity_store.rb
@@ -1,18 +1,18 @@
 module EntityStore
   module Controls
     module EntityStore
-      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, read_batch_size: nil, read_batch_size_keyword: nil)
-        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && read_batch_size.nil? && read_batch_size_keyword.nil?
+      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
+        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && reader_batch_size.nil? && reader_batch_size_keyword.nil?
           store_class = Example
         else
-          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, read_batch_size: read_batch_size, read_batch_size_keyword: read_batch_size_keyword)
+          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, reader_batch_size: reader_batch_size, reader_batch_size_keyword: reader_batch_size_keyword)
         end
 
         instance = store_class.build
         instance
       end
 
-      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, read_batch_size: nil, read_batch_size_keyword: nil)
+      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
         if category == :none
           category = nil
         else
@@ -37,10 +37,10 @@ module EntityStore
           reader_class ||= Controls::Reader::Example
         end
 
-        if read_batch_size == :none
-          read_batch_size = nil
+        if reader_batch_size == :none
+          reader_batch_size = nil
         else
-          read_batch_size ||= Controls::Reader::BatchSize.example
+          reader_batch_size ||= Controls::Reader::BatchSize.example
         end
 
         Class.new do
@@ -50,10 +50,10 @@ module EntityStore
           entity entity_class
           projection projection_class
 
-          if read_batch_size_keyword.nil?
-            reader reader_class, read_batch_size
+          if reader_batch_size_keyword.nil?
+            reader reader_class, reader_batch_size
           else
-            reader reader_class, batch_size: read_batch_size_keyword
+            reader reader_class, batch_size: reader_batch_size_keyword
           end
 
           unless snapshot_class.nil?

--- a/lib/entity_store/controls/entity_store.rb
+++ b/lib/entity_store/controls/entity_store.rb
@@ -1,18 +1,18 @@
 module EntityStore
   module Controls
     module EntityStore
-      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
-        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && reader_batch_size.nil? && reader_batch_size_keyword.nil?
+      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, read_batch_size: nil, read_batch_size_keyword: nil)
+        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && read_batch_size.nil? && read_batch_size_keyword.nil?
           store_class = Example
         else
-          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, reader_batch_size: reader_batch_size, reader_batch_size_keyword: reader_batch_size_keyword)
+          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, read_batch_size: read_batch_size, read_batch_size_keyword: read_batch_size_keyword)
         end
 
         instance = store_class.build
         instance
       end
 
-      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
+      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, read_batch_size: nil, read_batch_size_keyword: nil)
         if category == :none
           category = nil
         else
@@ -37,10 +37,10 @@ module EntityStore
           reader_class ||= Controls::Reader::Example
         end
 
-        if reader_batch_size == :none
-          reader_batch_size = nil
+        if read_batch_size == :none
+          read_batch_size = nil
         else
-          reader_batch_size ||= Controls::Reader::BatchSize.example
+          read_batch_size ||= Controls::Reader::BatchSize.example
         end
 
         Class.new do
@@ -50,10 +50,10 @@ module EntityStore
           entity entity_class
           projection projection_class
 
-          if reader_batch_size_keyword.nil?
-            reader reader_class, reader_batch_size
+          if read_batch_size_keyword.nil?
+            reader reader_class, read_batch_size
           else
-            reader reader_class, batch_size: reader_batch_size_keyword
+            reader reader_class, batch_size: read_batch_size_keyword
           end
 
           unless snapshot_class.nil?

--- a/lib/entity_store/controls/entity_store.rb
+++ b/lib/entity_store/controls/entity_store.rb
@@ -1,18 +1,18 @@
 module EntityStore
   module Controls
     module EntityStore
-      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil)
-        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil?  && snapshot_interval_keyword.nil?
+      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
+        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && snapshot_interval_keyword.nil? && reader_batch_size.nil? && reader_batch_size_keyword.nil?
           store_class = Example
         else
-          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword)
+          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, snapshot_interval_keyword: snapshot_interval_keyword, reader_batch_size: reader_batch_size, reader_batch_size_keyword: reader_batch_size_keyword)
         end
 
         instance = store_class.build
         instance
       end
 
-      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil)
+      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, snapshot_interval_keyword: nil, reader_batch_size: nil, reader_batch_size_keyword: nil)
         if category == :none
           category = nil
         else
@@ -37,13 +37,24 @@ module EntityStore
           reader_class ||= Controls::Reader::Example
         end
 
+        if reader_batch_size == :none
+          reader_batch_size = nil
+        else
+          reader_batch_size ||= Controls::Reader::BatchSize.example
+        end
+
         Class.new do
           include ::EntityStore
 
           category category
           entity entity_class
           projection projection_class
-          reader reader_class
+
+          if reader_batch_size_keyword.nil?
+            reader reader_class, reader_batch_size
+          else
+            reader reader_class, batch_size: reader_batch_size_keyword
+          end
 
           unless snapshot_class.nil?
             if snapshot_interval_keyword.nil?

--- a/lib/entity_store/controls/reader.rb
+++ b/lib/entity_store/controls/reader.rb
@@ -8,6 +8,12 @@ module EntityStore
       class Example
         include MessageStore::Read
       end
+
+      module BatchSize
+        def self.example
+          11
+        end
+      end
     end
   end
 end

--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -28,7 +28,7 @@ module EntityStore
       virtual :category
       virtual :reader_class
       virtual :projection_class
-      virtual :read_batch_size
+      virtual :reader_batch_size
       virtual :snapshot_class
       virtual :snapshot_interval
 
@@ -122,7 +122,7 @@ module EntityStore
     project = projection_class.build(entity)
 
     logger.trace(tag: :store) { "Reading (Stream Name: #{stream_name}, Position: #{current_position}" }
-    reader_class.(stream_name, position: start_position, batch_size: read_batch_size, session: session) do |event_data|
+    reader_class.(stream_name, position: start_position, batch_size: reader_batch_size, session: session) do |event_data|
       project.(event_data)
       current_position = event_data.position
 
@@ -214,7 +214,7 @@ module EntityStore
         cls
       end
 
-      define_method :read_batch_size do
+      define_method :reader_batch_size do
         batch_size
       end
     end

--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -28,6 +28,7 @@ module EntityStore
       virtual :category
       virtual :reader_class
       virtual :projection_class
+      virtual :reader_batch_size
       virtual :snapshot_class
       virtual :snapshot_interval
 
@@ -206,9 +207,15 @@ module EntityStore
   end
 
   module ReaderMacro
-    def reader_macro(cls)
+    def reader_macro(cls, batch_sz=nil, batch_size: nil)
+      batch_size ||= batch_sz
+
       define_method :reader_class do
         cls
+      end
+
+      define_method :reader_batch_size do
+        batch_size
       end
     end
     alias_method :reader, :reader_macro

--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -5,6 +5,7 @@ module EntityStore
     cls.class_exec do
       Configure.activate(self)
       Dependency.activate(self)
+      Virtual.activate(self)
 
       include Log::Dependency
       include Messaging::Category

--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -3,6 +3,8 @@ module EntityStore
 
   def self.included(cls)
     cls.class_exec do
+      Configure.activate(self)
+
       include Log::Dependency
       include Messaging::Category
 

--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -28,7 +28,7 @@ module EntityStore
       virtual :category
       virtual :reader_class
       virtual :projection_class
-      virtual :reader_batch_size
+      virtual :read_batch_size
       virtual :snapshot_class
       virtual :snapshot_interval
 
@@ -122,7 +122,7 @@ module EntityStore
     project = projection_class.build(entity)
 
     logger.trace(tag: :store) { "Reading (Stream Name: #{stream_name}, Position: #{current_position}" }
-    reader_class.(stream_name, position: start_position, session: session) do |event_data|
+    reader_class.(stream_name, position: start_position, batch_size: read_batch_size, session: session) do |event_data|
       project.(event_data)
       current_position = event_data.position
 
@@ -214,7 +214,7 @@ module EntityStore
         cls
       end
 
-      define_method :reader_batch_size do
+      define_method :read_batch_size do
         batch_size
       end
     end

--- a/lib/entity_store/entity_store.rb
+++ b/lib/entity_store/entity_store.rb
@@ -4,6 +4,7 @@ module EntityStore
   def self.included(cls)
     cls.class_exec do
       Configure.activate(self)
+      Dependency.activate(self)
 
       include Log::Dependency
       include Messaging::Category

--- a/test/automated.rb
+++ b/test/automated.rb
@@ -1,6 +1,8 @@
-require_relative 'test_init'
+require_relative './test_init'
 
-TestBench::Runner.(
-  'automated/**/*.rb',
-  exclude_pattern: %r{\/_|sketch|(_init\.rb|_tests\.rb)\z}
+require 'test_bench/cli'
+
+TestBench::CLI.(
+  exclude_pattern: '/_|sketch|(_init\.rb|_tests\.rb)\z',
+  tests_directory: 'test/automated'
 ) or exit 1

--- a/test/automated/reader_declaration/optional_batch_size.rb
+++ b/test/automated/reader_declaration/optional_batch_size.rb
@@ -6,27 +6,27 @@ context "Reader Declaration" do
       batch_size = Controls::Reader::BatchSize.example
 
       context "Positional Argument" do
-        store = Controls::EntityStore.example(reader_batch_size: batch_size)
+        store = Controls::EntityStore.example(read_batch_size: batch_size)
 
         test "Given batch size is assigned to store" do
-          assert(store.reader_batch_size == batch_size)
+          assert(store.read_batch_size == batch_size)
         end
       end
 
       context "Keyword Argument" do
-        store = Controls::EntityStore.example(reader_batch_size_keyword: batch_size)
+        store = Controls::EntityStore.example(read_batch_size_keyword: batch_size)
 
         test "Given batch size is assigned to store" do
-          assert(store.reader_batch_size == batch_size)
+          assert(store.read_batch_size == batch_size)
         end
       end
     end
 
     context "Omitted" do
-      store = Controls::EntityStore.example(reader_batch_size: :none)
+      store = Controls::EntityStore.example(read_batch_size: :none)
 
-      test "Reader batch size is not set on store" do
-        assert(store.reader_batch_size.nil?)
+      test "Read batch size is not set on store" do
+        assert(store.read_batch_size.nil?)
       end
     end
   end

--- a/test/automated/reader_declaration/optional_batch_size.rb
+++ b/test/automated/reader_declaration/optional_batch_size.rb
@@ -6,27 +6,27 @@ context "Reader Declaration" do
       batch_size = Controls::Reader::BatchSize.example
 
       context "Positional Argument" do
-        store = Controls::EntityStore.example(read_batch_size: batch_size)
+        store = Controls::EntityStore.example(reader_batch_size: batch_size)
 
         test "Given batch size is assigned to store" do
-          assert(store.read_batch_size == batch_size)
+          assert(store.reader_batch_size == batch_size)
         end
       end
 
       context "Keyword Argument" do
-        store = Controls::EntityStore.example(read_batch_size_keyword: batch_size)
+        store = Controls::EntityStore.example(reader_batch_size_keyword: batch_size)
 
         test "Given batch size is assigned to store" do
-          assert(store.read_batch_size == batch_size)
+          assert(store.reader_batch_size == batch_size)
         end
       end
     end
 
     context "Omitted" do
-      store = Controls::EntityStore.example(read_batch_size: :none)
+      store = Controls::EntityStore.example(reader_batch_size: :none)
 
       test "Read batch size is not set on store" do
-        assert(store.read_batch_size.nil?)
+        assert(store.reader_batch_size.nil?)
       end
     end
   end

--- a/test/automated/reader_declaration/optional_batch_size.rb
+++ b/test/automated/reader_declaration/optional_batch_size.rb
@@ -1,0 +1,33 @@
+require_relative '../automated_init'
+
+context "Reader Declaration" do
+  context "Optional Batch Size" do
+    context "Supplied" do
+      batch_size = Controls::Reader::BatchSize.example
+
+      context "Positional Argument" do
+        store = Controls::EntityStore.example(reader_batch_size: batch_size)
+
+        test "Given batch size is assigned to store" do
+          assert(store.reader_batch_size == batch_size)
+        end
+      end
+
+      context "Keyword Argument" do
+        store = Controls::EntityStore.example(reader_batch_size_keyword: batch_size)
+
+        test "Given batch size is assigned to store" do
+          assert(store.reader_batch_size == batch_size)
+        end
+      end
+    end
+
+    context "Omitted" do
+      store = Controls::EntityStore.example(reader_batch_size: :none)
+
+      test "Reader batch size is not set on store" do
+        assert(store.reader_batch_size.nil?)
+      end
+    end
+  end
+end

--- a/test/automated/reader_declaration/optional_batch_size.rb
+++ b/test/automated/reader_declaration/optional_batch_size.rb
@@ -5,20 +5,10 @@ context "Reader Declaration" do
     context "Supplied" do
       batch_size = Controls::Reader::BatchSize.example
 
-      context "Positional Argument" do
-        store = Controls::EntityStore.example(reader_batch_size: batch_size)
+      store = Controls::EntityStore.example(reader_batch_size: batch_size)
 
-        test "Given batch size is assigned to store" do
-          assert(store.reader_batch_size == batch_size)
-        end
-      end
-
-      context "Keyword Argument" do
-        store = Controls::EntityStore.example(reader_batch_size_keyword: batch_size)
-
-        test "Given batch size is assigned to store" do
-          assert(store.reader_batch_size == batch_size)
-        end
+      test "Given batch size is assigned to store" do
+        assert(store.reader_batch_size == batch_size)
       end
     end
 

--- a/test/automated/reader_declaration/reader_declaration.rb
+++ b/test/automated/reader_declaration/reader_declaration.rb
@@ -1,4 +1,4 @@
-require_relative 'automated_init'
+require_relative '../automated_init'
 
 context "Reader Declaration" do
   context "Reader is declared" do


### PR DESCRIPTION
* Argument can be positional or a keyword (patterned after the snapshot interval argument, which can also be either keyword or positional)
* Note: the testing of the actual reader is done in the [entity-store-postgres-test](https://github.com/eventide-project/entity-store-postgres-test) project
* Also note: it's not straightforward how to prove that the batch size is actually used by the reader; this is because there's no observable difference between the store using one batch size versus another. I'm not sure the best way to test this aside from manual testing