### PR TITLE
Entity ID attribute is specifiable and set on new entitites

### DIFF
--- a/lib/entity_store/controls/entity_store.rb
+++ b/lib/entity_store/controls/entity_store.rb
@@ -1,18 +1,18 @@
 module EntityStore
   module Controls
     module EntityStore
-      def self.example(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, reader_batch_size: nil)
-        if category.nil? && entity_class.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && reader_batch_size.nil?
+      def self.example(category: nil, entity_class: nil, entity_id_attribute: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, reader_batch_size: nil)
+        if category.nil? && entity_class.nil? && entity_id_attribute.nil? && projection_class.nil? && reader_class.nil? && snapshot_class.nil? && snapshot_interval.nil? && reader_batch_size.nil?
           store_class = Example
         else
-          store_class = example_class(category: category, entity_class: entity_class, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, reader_batch_size: reader_batch_size)
+          store_class = example_class(category: category, entity_class: entity_class, entity_id_attribute: entity_id_attribute, projection_class: projection_class, reader_class: reader_class, snapshot_class: snapshot_class, snapshot_interval: snapshot_interval, reader_batch_size: reader_batch_size)
         end
 
         instance = store_class.build
         instance
       end
 
-      def self.example_class(category: nil, entity_class: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, reader_batch_size: nil)
+      def self.example_class(category: nil, entity_class: nil, entity_id_attribute: nil, projection_class: nil, reader_class: nil, snapshot_class: nil, snapshot_interval: nil, reader_batch_size: nil)
         if category == :none
           category = nil
         else
@@ -47,7 +47,7 @@ module EntityStore
           include ::EntityStore
 
           category category
-          entity entity_class
+          entity entity_class, id_attribute: entity_id_attribute
           projection projection_class
           reader reader_class, batch_size: reader_batch_size
 

--- a/test/automated/entity_id_attribute_declaration.rb
+++ b/test/automated/entity_id_attribute_declaration.rb
@@ -1,0 +1,40 @@
+require_relative 'automated_init'
+
+context "Entity ID Attribute Declaration" do
+  context "Entity ID Attribute Is Declared" do
+    context "Extant ID Attribute" do
+      entity_class = Class.new do
+        attr_accessor :some_id
+      end
+
+      entity_id_attribute = :some_id
+      store = Controls::EntityStore.example(entity_class: entity_class, entity_id_attribute: entity_id_attribute)
+
+      test "Entity ID attribute is assigned to the store" do
+        assert(store.entity_id_attribute == entity_id_attribute)
+      end
+    end
+
+    context "Non-Extant ID Attribute" do
+      context "Build" do
+        entity_class = Class.new
+        entity_id_attribute = :some_id
+
+        test "Is an error" do
+          assert_raises(EntityStore::Error) do
+            Controls::EntityStore.example(entity_class: entity_class, entity_id_attribute: entity_id_attribute)
+          end
+        end
+      end
+    end
+  end
+
+  context "Entity ID Attribute Is Not Declared" do
+    entity_class = Class.new
+    store = Controls::EntityStore.example(entity_class: entity_class)
+
+    test "Entity ID attribute is not set" do
+      assert(store.entity_id_attribute.nil?)
+    end
+  end
+end

--- a/test/automated/new_entity/new_entity.rb
+++ b/test/automated/new_entity/new_entity.rb
@@ -2,6 +2,7 @@ require_relative '../automated_init'
 
 context "New Entity" do
   context "Factory method is defined on the entity class" do
+    id = Controls::ID.example
     entity_class = Class.new do
       attr_accessor :build_called
 
@@ -14,7 +15,7 @@ context "New Entity" do
 
     store = Controls::EntityStore.example(entity_class: entity_class)
 
-    entity = store.new_entity
+    entity = store.new_entity(id)
 
     test "Factory method is used" do
       assert(entity.build_called)
@@ -22,14 +23,31 @@ context "New Entity" do
   end
 
   context "No factory method is defined on the entity class" do
+    id = Controls::ID.example
     entity_class = Class.new
 
     store = Controls::EntityStore.example(entity_class: entity_class)
 
-    entity = store.new_entity
+    entity = store.new_entity(id)
 
     test "Entity is instantiated" do
       assert(entity.is_a?(entity_class))
+    end
+  end
+
+  context "ID attribute is supplied" do
+    id = Controls::ID.example
+
+    entity_class = Class.new do
+      attr_accessor :some_id
+    end
+
+    store = Controls::EntityStore.example(entity_class: entity_class, entity_id_attribute: :some_id)
+
+    entity = store.new_entity(id)
+
+    test "ID is set" do
+      assert(entity.some_id == id)
     end
   end
 end


### PR DESCRIPTION
Based on a conversation a while ago with @sbellware. We typically set an entity's ID in the projection. As such, we must set it in every message. However, we know an entity's ID during construction of that entity AND that ID should never change (that would be maximally surprising). 

So, if we allow the entity to be constructed with its ID, then our entities are always identified and the setting of them can be removed from the projection which makes the intent of the projections more clear, in my opinion.